### PR TITLE
Create ARM and x86 builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,7 +23,9 @@ jobs:
           export VERSION=${GITHUB_REF#refs/tags/}
           export VERSION_MINOR=$(echo ${VERSION} | awk '{match($0,"v[0-9].[0-9]",a)}END{print a[0]}')
           export VERSION_MAJOR=$(echo ${VERSION} | awk '{match($0,"v[0-9]",a)}END{print a[0]}')
-          docker build --build-arg ACTION_VERSION=${VERSION} \
+          docker buildx create --use
+          docker build --platform linux/amd64,linux/arm64 \
+          --build-arg ACTION_VERSION=${VERSION} \
           -t morphy/revive-action \
           -t morphy/revive-action:${VERSION} \
           -t morphy/revive-action:${VERSION_MINOR} \


### PR DESCRIPTION
We're migrating to ARM based runners.

This PR enables multi-platform compilation when container images are created.