### PR TITLE
Change target container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY . .
 
 RUN go install -ldflags="-X 'main.version=${ACTION_VERSION}'"
 
-FROM alpine:3.20.2
+FROM golang:1.22.5-alpine
 
 LABEL repository="https://github.com/morphy2k/revive-action"
 LABEL homepage="https://github.com/morphy2k/revive-action"


### PR DESCRIPTION
Since version 1.3.9, Revive requires a Go installation. It is therefore necessary to ship the image with Go.

Unfortunately, the downside of this is that it significantly increases the size of the image from around 25 MB to 260 MB.

Fixes #135 